### PR TITLE
앨범 자세히보기(댓글 리사이클러뷰 출력 | 사진 크기변화 애니메이션 적용)

### DIFF
--- a/app/src/main/java/kids/baba/mobile/core/constant/PrefsKey.kt
+++ b/app/src/main/java/kids/baba/mobile/core/constant/PrefsKey.kt
@@ -3,4 +3,5 @@ package kids.baba.mobile.core.constant
 object PrefsKey {
     const val ACCESS_TOKEN_KEY = "ACCESS_TOKEN_KEY"
     const val REFRESH_TOKEN_KEY = "REFRESH_TOKEN_KEY"
+    const val MEMBER_KEY = "MEMBER_KEY"
 }

--- a/app/src/main/java/kids/baba/mobile/core/error/MemberNotFoundException.kt
+++ b/app/src/main/java/kids/baba/mobile/core/error/MemberNotFoundException.kt
@@ -1,0 +1,3 @@
+package kids.baba.mobile.core.error
+
+class MemberNotFoundException: Exception()

--- a/app/src/main/java/kids/baba/mobile/core/error/TokenEmptyException.kt
+++ b/app/src/main/java/kids/baba/mobile/core/error/TokenEmptyException.kt
@@ -1,0 +1,3 @@
+package kids.baba.mobile.core.error
+
+class TokenEmptyException(message: String): Exception(message)

--- a/app/src/main/java/kids/baba/mobile/core/utils/EncryptedPrefs.kt
+++ b/app/src/main/java/kids/baba/mobile/core/utils/EncryptedPrefs.kt
@@ -4,9 +4,13 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.google.gson.GsonBuilder
+import kids.baba.mobile.core.error.MemberNotFoundException
+import kids.baba.mobile.domain.model.MemberModel
 
 object EncryptedPrefs {
     private var prefs: SharedPreferences? = null
+    private val gson = GsonBuilder().create()
 
     fun initSharedPreferences(context: Context) {
         synchronized(this) {
@@ -22,6 +26,16 @@ object EncryptedPrefs {
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             )
         }
+    }
+
+    fun putMember(key: String, value: MemberModel){
+        val json = gson.toJson(value,MemberModel::class.java)
+        putString(key,json)
+    }
+
+    fun getMember(key: String): MemberModel{
+        val value = prefs?.getString(key,null) ?: throw MemberNotFoundException()
+        return gson.fromJson(value, MemberModel::class.java)
     }
 
     fun putString(key: String, value: String) {
@@ -67,4 +81,6 @@ object EncryptedPrefs {
     fun getBoolean(key: String): Boolean {
         return prefs?.getBoolean(key, false) ?: false
     }
+
+
 }

--- a/app/src/main/java/kids/baba/mobile/data/datasource/member/MemberRemoteDataSourceImpl.kt
+++ b/app/src/main/java/kids/baba/mobile/data/datasource/member/MemberRemoteDataSourceImpl.kt
@@ -15,6 +15,7 @@ class MemberRemoteDataSourceImpl @Inject constructor(private val memberApi: Memb
             .onSuccess { resp ->
                 if (resp.isSuccessful) {
                     val data = resp.body() ?: throw Throwable("서버로부터 받은 사용자 정보가 null임")
+
                     emit(data)
                 } else {
                     throw Throwable("사용자 정보를 받아올 수 없음.")

--- a/app/src/main/java/kids/baba/mobile/domain/model/MemberModel.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/model/MemberModel.kt
@@ -4,6 +4,5 @@ data class MemberModel(
     val name: String,
     val introduction: String,
     val iconName: String,
-    val iconColor: String,
-    val email: String
+    val iconColor: String
 )

--- a/app/src/main/java/kids/baba/mobile/domain/model/UserProfileIcon.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/model/UserProfileIcon.kt
@@ -1,0 +1,21 @@
+package kids.baba.mobile.domain.model
+
+enum class UserProfileIcon(
+) {
+    PROFILE_W_1,
+    PROFILE_W_2,
+    PROFILE_W_4,
+    PROFILE_W_3,
+    PROFILE_W_5,
+    PROFILE_M_1,
+    PROFILE_M_2,
+    PROFILE_M_3,
+    PROFILE_M_4,
+    PROFILE_M_5,
+    PROFILE_M_6,
+    PROFILE_G_1,
+    PROFILE_G_2,
+    PROFILE_G_3,
+    PROFILE_G_4,
+    PROFILE_BABY_1
+}

--- a/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
@@ -4,14 +4,13 @@ import android.util.Log
 import kids.baba.mobile.core.constant.PrefsKey
 import kids.baba.mobile.core.utils.EncryptedPrefs
 import kids.baba.mobile.domain.repository.MemberRepository
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class GetMemberUseCase @Inject constructor(private val memberRepository: MemberRepository) {
     private val tag = "GetMemberUseCase"
 
-    suspend fun getMe() = flow {
+    suspend fun getMe() = runCatching {
         val accessToken = EncryptedPrefs.getString(PrefsKey.ACCESS_TOKEN_KEY)
 
         if (accessToken.isEmpty()) {
@@ -20,11 +19,8 @@ class GetMemberUseCase @Inject constructor(private val memberRepository: MemberR
             throw Throwable(msg)
         }
 
-        memberRepository.getMe(accessToken).catch {
-            Log.e(tag, it.message.toString())
-            throw it
-        }.collect {
-            emit(it)
-        }
+        val user = memberRepository.getMe(accessToken).first()
+        EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY,user)
+        user
     }
 }

--- a/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
@@ -6,6 +6,10 @@ import kids.baba.mobile.core.error.MemberNotFoundException
 import kids.baba.mobile.core.error.TokenEmptyException
 import kids.baba.mobile.core.utils.EncryptedPrefs
 import kids.baba.mobile.domain.repository.MemberRepository
+import kids.baba.mobile.presentation.mapper.toPresentation
+import kids.baba.mobile.presentation.model.MemberUiModel
+import kids.baba.mobile.presentation.model.UserIconUiModel
+import kids.baba.mobile.presentation.model.UserProfileIconUiModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -14,8 +18,8 @@ import javax.inject.Inject
 class GetMemberUseCase @Inject constructor(private val memberRepository: MemberRepository) {
     private val tag = "GetMemberUseCase"
 
-    suspend fun getMe() = flow {
-        emit(EncryptedPrefs.getMember(PrefsKey.MEMBER_KEY))
+    fun getMe() = flow {
+        emit(EncryptedPrefs.getMember(PrefsKey.MEMBER_KEY).toPresentation())
     }.catch {
         if(it is MemberNotFoundException) {
             val accessToken = EncryptedPrefs.getString(PrefsKey.ACCESS_TOKEN_KEY)
@@ -27,9 +31,15 @@ class GetMemberUseCase @Inject constructor(private val memberRepository: MemberR
             }
             val member = memberRepository.getMe(accessToken).first()
             EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY, member)
-            emit(member)
+            emit(member.toPresentation())
         } else {
-            throw it
+            val tempMember = MemberUiModel(
+                "이호성",
+                "안녕하세요",
+                UserIconUiModel(UserProfileIconUiModel.PROFILE_G_1,"#ff1234"),
+            )
+            emit(tempMember)
+//            throw it
         }
     }
 }

--- a/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
@@ -1,9 +1,7 @@
 package kids.baba.mobile.domain.usecase
 
-import android.util.Log
 import kids.baba.mobile.core.constant.PrefsKey
 import kids.baba.mobile.core.error.MemberNotFoundException
-import kids.baba.mobile.core.error.TokenEmptyException
 import kids.baba.mobile.core.utils.EncryptedPrefs
 import kids.baba.mobile.domain.repository.MemberRepository
 import kids.baba.mobile.presentation.mapper.toPresentation
@@ -17,7 +15,11 @@ import javax.inject.Inject
 
 class GetMemberUseCase @Inject constructor(private val memberRepository: MemberRepository) {
     private val tag = "GetMemberUseCase"
-
+    private val tempMember = MemberUiModel(
+        "이호성",
+        "안녕하세요",
+        UserIconUiModel(UserProfileIconUiModel.PROFILE_G_1,"#FFA500"),
+    )
     fun getMe() = flow {
         emit(EncryptedPrefs.getMember(PrefsKey.MEMBER_KEY).toPresentation())
     }.catch {
@@ -25,19 +27,18 @@ class GetMemberUseCase @Inject constructor(private val memberRepository: MemberR
             val accessToken = EncryptedPrefs.getString(PrefsKey.ACCESS_TOKEN_KEY)
 
             if (accessToken.isEmpty()) {
-                val msg = "accessToken이 존재하지 않음."
-                Log.e(tag, msg)
-                throw TokenEmptyException(msg)
+//           로그인 과정이 없어 에러가 발생하므로 잠시 주석 이후 합치는 과정에서 원복 해야함
+//                val msg = "accessToken이 존재하지 않음."
+//                Log.e(tag, msg)
+//                throw TokenEmptyException(msg)
+                emit(tempMember)
+            }else {
+                val member = memberRepository.getMe(accessToken).first()
+                EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY, member)
+                emit(member.toPresentation())
             }
-            val member = memberRepository.getMe(accessToken).first()
-            EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY, member)
-            emit(member.toPresentation())
+
         } else {
-            val tempMember = MemberUiModel(
-                "이호성",
-                "안녕하세요",
-                UserIconUiModel(UserProfileIconUiModel.PROFILE_G_1,"#ff1234"),
-            )
             emit(tempMember)
 //            throw it
         }

--- a/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
+++ b/app/src/main/java/kids/baba/mobile/domain/usecase/GetMemberUseCase.kt
@@ -2,25 +2,34 @@ package kids.baba.mobile.domain.usecase
 
 import android.util.Log
 import kids.baba.mobile.core.constant.PrefsKey
+import kids.baba.mobile.core.error.MemberNotFoundException
+import kids.baba.mobile.core.error.TokenEmptyException
 import kids.baba.mobile.core.utils.EncryptedPrefs
 import kids.baba.mobile.domain.repository.MemberRepository
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetMemberUseCase @Inject constructor(private val memberRepository: MemberRepository) {
     private val tag = "GetMemberUseCase"
 
-    suspend fun getMe() = runCatching {
-        val accessToken = EncryptedPrefs.getString(PrefsKey.ACCESS_TOKEN_KEY)
+    suspend fun getMe() = flow {
+        emit(EncryptedPrefs.getMember(PrefsKey.MEMBER_KEY))
+    }.catch {
+        if(it is MemberNotFoundException) {
+            val accessToken = EncryptedPrefs.getString(PrefsKey.ACCESS_TOKEN_KEY)
 
-        if (accessToken.isEmpty()) {
-            val msg = "accessToken이 존재하지 않음."
-            Log.e(tag, msg)
-            throw Throwable(msg)
+            if (accessToken.isEmpty()) {
+                val msg = "accessToken이 존재하지 않음."
+                Log.e(tag, msg)
+                throw TokenEmptyException(msg)
+            }
+            val member = memberRepository.getMe(accessToken).first()
+            EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY, member)
+            emit(member)
+        } else {
+            throw it
         }
-
-        val user = memberRepository.getMe(accessToken).first()
-        EncryptedPrefs.putMember(PrefsKey.MEMBER_KEY,user)
-        user
     }
 }

--- a/app/src/main/java/kids/baba/mobile/presentation/adapter/AlbumDetailCommentAdapter.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/adapter/AlbumDetailCommentAdapter.kt
@@ -1,0 +1,44 @@
+package kids.baba.mobile.presentation.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import kids.baba.mobile.R
+import kids.baba.mobile.databinding.ItemAlbumCommentBinding
+import kids.baba.mobile.presentation.model.CommentUiModel
+
+class AlbumDetailCommentAdapter
+    : ListAdapter<CommentUiModel, AlbumDetailCommentAdapter.CommentViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+        CommentViewHolder(parent)
+
+    override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class CommentViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.item_album_comment, parent, false)
+    ) {
+        private val binding = ItemAlbumCommentBinding.bind(itemView)
+
+        fun bind(comment: CommentUiModel){
+            binding.comment = comment
+        }
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<CommentUiModel>() {
+            override fun areItemsTheSame(oldItem: CommentUiModel, newItem: CommentUiModel) =
+                oldItem.commentId == newItem.commentId
+
+            override fun areContentsTheSame(
+                oldItem: CommentUiModel,
+                newItem: CommentUiModel
+            ): Boolean =
+                oldItem.hashCode() == newItem.hashCode()
+        }
+    }
+}

--- a/app/src/main/java/kids/baba/mobile/presentation/binding/BindingAdpater.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/binding/BindingAdpater.kt
@@ -2,7 +2,6 @@ package kids.baba.mobile.presentation.binding
 
 import android.graphics.Color
 import android.widget.ImageView
-import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
@@ -16,9 +15,7 @@ fun setIcon(imageView: ImageView, @DrawableRes res: Int) {
 
 @BindingAdapter("backGroundColor")
 fun setBackGroundColor(circleImageView: CircleImageView, colorString: String) {
-    @ColorInt
-    val a = Color.parseColor(colorString)
-    circleImageView.circleBackgroundColor = a
+    circleImageView.circleBackgroundColor = Color.parseColor(colorString)
 }
 
 @BindingAdapter("imageFromUrl")

--- a/app/src/main/java/kids/baba/mobile/presentation/binding/BindingAdpater.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/binding/BindingAdpater.kt
@@ -1,18 +1,28 @@
 package kids.baba.mobile.presentation.binding
 
+import android.graphics.Color
 import android.widget.ImageView
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import de.hdodenhof.circleimageview.CircleImageView
 
 
 @BindingAdapter("iconRes")
-fun setIcon(imageView: ImageView, @DrawableRes res: Int){
+fun setIcon(imageView: ImageView, @DrawableRes res: Int) {
     imageView.setImageResource(res)
 }
 
+@BindingAdapter("backGroundColor")
+fun setBackGroundColor(circleImageView: CircleImageView, colorString: String) {
+    @ColorInt
+    val a = Color.parseColor(colorString)
+    circleImageView.circleBackgroundColor = a
+}
+
 @BindingAdapter("imageFromUrl")
-fun setImageFromUrl(imageView: ImageView, url: String){
+fun setImageFromUrl(imageView: ImageView, url: String) {
     Glide.with(imageView.context)
         .load(url)
         .into(imageView)

--- a/app/src/main/java/kids/baba/mobile/presentation/event/AlbumDetailEvent.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/event/AlbumDetailEvent.kt
@@ -1,0 +1,7 @@
+package kids.baba.mobile.presentation.event
+
+import androidx.annotation.StringRes
+
+sealed class AlbumDetailEvent{
+    data class ShowSnackBar(@StringRes val message: Int): AlbumDetailEvent()
+}

--- a/app/src/main/java/kids/baba/mobile/presentation/event/IntroEvent.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/event/IntroEvent.kt
@@ -10,4 +10,6 @@ sealed class IntroEvent {
     data class MoveToCreateUserProfile(val signToken: String) : IntroEvent()
     data class MoveToInputBabiesInfo(val signToken: String, val userProfile: UserProfile) : IntroEvent()
     data class MoveToMain(val member: MemberModel) : IntroEvent()
+
+    object IntroError: IntroEvent()
 }

--- a/app/src/main/java/kids/baba/mobile/presentation/event/IntroEvent.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/event/IntroEvent.kt
@@ -1,6 +1,5 @@
 package kids.baba.mobile.presentation.event
 
-import kids.baba.mobile.domain.model.MemberModel
 import kids.baba.mobile.presentation.model.UserProfile
 
 sealed class IntroEvent {
@@ -9,7 +8,7 @@ sealed class IntroEvent {
     data class MoveToAgree(val socialToken: String) : IntroEvent()
     data class MoveToCreateUserProfile(val signToken: String) : IntroEvent()
     data class MoveToInputBabiesInfo(val signToken: String, val userProfile: UserProfile) : IntroEvent()
-    data class MoveToMain(val member: MemberModel) : IntroEvent()
+    object MoveToMain : IntroEvent()
 
     object IntroError: IntroEvent()
 }

--- a/app/src/main/java/kids/baba/mobile/presentation/mapper/MemberUiModelMapper.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/mapper/MemberUiModelMapper.kt
@@ -1,0 +1,26 @@
+package kids.baba.mobile.presentation.mapper
+
+import kids.baba.mobile.domain.model.MemberModel
+import kids.baba.mobile.presentation.model.MemberUiModel
+import kids.baba.mobile.presentation.model.UserIconUiModel
+import kids.baba.mobile.presentation.model.UserProfileIconUiModel
+
+fun MemberModel.toPresentation(): MemberUiModel {
+    return MemberUiModel(
+        name = name,
+        introduction = introduction,
+        userIconUiModel = UserIconUiModel(
+            userProfileIconUiModel = UserProfileIconUiModel.valueOf(iconName),
+            iconColor = iconColor
+        )
+    )
+}
+
+fun MemberUiModel.toDomain(): MemberModel {
+    return MemberModel(
+        name = name,
+        introduction = introduction,
+        iconName = userIconUiModel.userProfileIconUiModel.name,
+        iconColor = userIconUiModel.iconColor
+    )
+}

--- a/app/src/main/java/kids/baba/mobile/presentation/mapper/UerProfileUiModelMapper.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/mapper/UerProfileUiModelMapper.kt
@@ -1,0 +1,25 @@
+package kids.baba.mobile.presentation.mapper
+
+import kids.baba.mobile.domain.model.UserProfileIcon
+import kids.baba.mobile.presentation.model.UserProfileIconUiModel
+
+fun UserProfileIconUiModel.toDomain(): UserProfileIcon {
+    return when (this) {
+        UserProfileIconUiModel.PROFILE_G_1 -> UserProfileIcon.PROFILE_G_1
+        UserProfileIconUiModel.PROFILE_W_1 -> UserProfileIcon.PROFILE_W_1
+        UserProfileIconUiModel.PROFILE_W_2 -> UserProfileIcon.PROFILE_W_2
+        UserProfileIconUiModel.PROFILE_W_3 -> UserProfileIcon.PROFILE_W_3
+        UserProfileIconUiModel.PROFILE_W_4 -> UserProfileIcon.PROFILE_W_4
+        UserProfileIconUiModel.PROFILE_W_5 -> UserProfileIcon.PROFILE_W_5
+        UserProfileIconUiModel.PROFILE_M_1 -> UserProfileIcon.PROFILE_M_1
+        UserProfileIconUiModel.PROFILE_M_2 -> UserProfileIcon.PROFILE_M_2
+        UserProfileIconUiModel.PROFILE_M_3 -> UserProfileIcon.PROFILE_M_3
+        UserProfileIconUiModel.PROFILE_M_4 -> UserProfileIcon.PROFILE_M_4
+        UserProfileIconUiModel.PROFILE_M_5 -> UserProfileIcon.PROFILE_M_5
+        UserProfileIconUiModel.PROFILE_M_6 -> UserProfileIcon.PROFILE_M_6
+        UserProfileIconUiModel.PROFILE_G_2 -> UserProfileIcon.PROFILE_G_2
+        UserProfileIconUiModel.PROFILE_G_3 -> UserProfileIcon.PROFILE_G_3
+        UserProfileIconUiModel.PROFILE_G_4 -> UserProfileIcon.PROFILE_G_4
+        UserProfileIconUiModel.PROFILE_BABY_1 -> UserProfileIcon.PROFILE_BABY_1
+    }
+}

--- a/app/src/main/java/kids/baba/mobile/presentation/model/CommentUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/CommentUiModel.kt
@@ -1,6 +1,5 @@
 package kids.baba.mobile.presentation.model
 
-import androidx.annotation.DrawableRes
 import java.time.LocalDateTime
 
 data class CommentUiModel(
@@ -8,8 +7,7 @@ data class CommentUiModel(
     val memberId: String,
     val name: String,
     val relation: String,
-    @DrawableRes
-    val iconName: Int,
+    val profileIcon: UserProfileIconUiModel,
     val iconColor: String,
     val tag: String,
     val comment: String,

--- a/app/src/main/java/kids/baba/mobile/presentation/model/MemberUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/MemberUiModel.kt
@@ -1,0 +1,7 @@
+package kids.baba.mobile.presentation.model
+
+data class MemberUiModel(
+    val name: String,
+    val introduction: String,
+    val userIconUiModel: UserIconUiModel
+)

--- a/app/src/main/java/kids/baba/mobile/presentation/model/UserIconUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/UserIconUiModel.kt
@@ -1,9 +1,6 @@
 package kids.baba.mobile.presentation.model
 
-import androidx.annotation.DrawableRes
-
 data class UserIconUiModel(
-    @DrawableRes
-    val iconName: Int,
+    val userProfileIconUiModel: UserProfileIconUiModel,
     val iconColor: String
 )

--- a/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
@@ -5,23 +5,23 @@ import kids.baba.mobile.R
 
 enum class UserProfileIconUiModel(
     @DrawableRes
-    iconRes: Int,
-    selected: Boolean
+    iconRes: Int
 ) {
-    PROFILE_W_1(R.drawable.profile_w_1, false),
-    PROFILE_W_2(R.drawable.profile_w_2, false),
-    PROFILE_W_4(R.drawable.profile_w_4, false),
-    PROFILE_W_3(R.drawable.profile_w_3, false),
-    PROFILE_W_5(R.drawable.profile_w_5, false),
-    PROFILE_M_1(R.drawable.profile_m_1, false),
-    PROFILE_M_2(R.drawable.profile_m_2, false),
-    PROFILE_M_3(R.drawable.profile_m_3, false),
-    PROFILE_M_4(R.drawable.profile_m_4, false),
-    PROFILE_M_5(R.drawable.profile_m_5, false),
-    PROFILE_M_6(R.drawable.profile_m_6, false),
-    PROFILE_G_1(R.drawable.profile_g_1, false),
-    PROFILE_G_2(R.drawable.profile_g_2, false),
-    PROFILE_G_3(R.drawable.profile_g_3, false),
-    PROFILE_G_4(R.drawable.profile_g_4, false),
-    PROFILE_BABY_1(R.drawable.profile_baby_1,false)
+    PROFILE_W_1(R.drawable.profile_w_1),
+    PROFILE_W_2(R.drawable.profile_w_2),
+    PROFILE_W_4(R.drawable.profile_w_4),
+    PROFILE_W_3(R.drawable.profile_w_3),
+    PROFILE_W_5(R.drawable.profile_w_5),
+    PROFILE_M_1(R.drawable.profile_m_1),
+    PROFILE_M_2(R.drawable.profile_m_2),
+    PROFILE_M_3(R.drawable.profile_m_3),
+    PROFILE_M_4(R.drawable.profile_m_4),
+    PROFILE_M_5(R.drawable.profile_m_5),
+    PROFILE_M_6(R.drawable.profile_m_6),
+    PROFILE_G_1(R.drawable.profile_g_1),
+    PROFILE_G_2(R.drawable.profile_g_2),
+    PROFILE_G_3(R.drawable.profile_g_3),
+    PROFILE_G_4(R.drawable.profile_g_4),
+    PROFILE_BABY_1(R.drawable.profile_baby_1)
 }
+

--- a/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
@@ -1,0 +1,27 @@
+package kids.baba.mobile.presentation.model
+
+import androidx.annotation.DrawableRes
+import kids.baba.mobile.R
+
+enum class UserProfileIconUiModel(
+    @DrawableRes
+    iconRes: Int,
+    selected: Boolean
+) {
+    PROFILE_W_1(R.drawable.profile_w_1, false),
+    PROFILE_W_2(R.drawable.profile_w_2, false),
+    PROFILE_W_4(R.drawable.profile_w_4, false),
+    PROFILE_W_3(R.drawable.profile_w_3, false),
+    PROFILE_W_5(R.drawable.profile_w_5, false),
+    PROFILE_M_1(R.drawable.profile_m_1, false),
+    PROFILE_M_2(R.drawable.profile_m_2, false),
+    PROFILE_M_3(R.drawable.profile_m_3, false),
+    PROFILE_M_4(R.drawable.profile_m_4, false),
+    PROFILE_M_5(R.drawable.profile_m_5, false),
+    PROFILE_M_6(R.drawable.profile_m_6, false),
+    PROFILE_G_1(R.drawable.profile_g_1, false),
+    PROFILE_G_2(R.drawable.profile_g_2, false),
+    PROFILE_G_3(R.drawable.profile_g_3, false),
+    PROFILE_G_4(R.drawable.profile_g_4, false),
+    PROFILE_BABY_1(R.drawable.profile_baby_1,false)
+}

--- a/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/model/UserProfileIconUiModel.kt
@@ -5,7 +5,7 @@ import kids.baba.mobile.R
 
 enum class UserProfileIconUiModel(
     @DrawableRes
-    iconRes: Int
+    val iconRes: Int
 ) {
     PROFILE_W_1(R.drawable.profile_w_1),
     PROFILE_W_2(R.drawable.profile_w_2),

--- a/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
@@ -1,5 +1,6 @@
 package kids.baba.mobile.presentation.view
 
+import android.animation.ValueAnimator
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,9 +21,12 @@ class AlbumDetailDialog : DialogFragment() {
     private val binding
         get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
 
-    private val viewModel : AlbumDetailViewModel by viewModels()
+    private val viewModel: AlbumDetailViewModel by viewModels()
 
     private lateinit var commentAdapter: AlbumDetailCommentAdapter
+
+    private var imageWidth: Int = 0
+    private var imageHeight: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,6 +48,12 @@ class AlbumDetailDialog : DialogFragment() {
         setBinding()
         setCloseBtn()
         setCommentRecyclerView()
+        setImgScaleAnim()
+    }
+
+    private fun getImgSize() {
+        imageWidth = binding.cvBabyPhoto.width
+        imageHeight = binding.cvBabyPhoto.height
     }
 
     private fun setCommentRecyclerView() {
@@ -51,20 +61,60 @@ class AlbumDetailDialog : DialogFragment() {
         binding.rvAlbumComment.adapter = commentAdapter
 
         viewLifecycleOwner.repeatOnStarted {
-            viewModel.albumDetail.collect{
+            viewModel.albumDetail.collect {
                 commentAdapter.submitList(it?.comments)
             }
         }
 
     }
 
+    private fun setImgScaleAnim() {
+        val scaleUpAnim = ValueAnimator.ofFloat(1f, 4f)
+
+        scaleUpAnim.addUpdateListener { animation ->
+            val layoutParams = binding.cvBabyPhoto.layoutParams
+            val value = animation.animatedValue as Float
+            binding.cvBabyPhoto.layoutParams.width = (imageWidth * value).toInt()
+            binding.cvBabyPhoto.layoutParams.height = (imageHeight * value).toInt()
+            binding.cvBabyPhoto.layoutParams = layoutParams
+        }
+        scaleUpAnim.duration = 500 // 애니메이션 지속 시간 설정 (1000ms = 1초)
+
+        val scaleDownAnim = ValueAnimator.ofFloat(1f, 0.25f)
+        scaleDownAnim.addUpdateListener { animation ->
+            val layoutParams = binding.cvBabyPhoto.layoutParams
+            val value = animation.animatedValue as Float
+            layoutParams.width = (imageWidth * value).toInt()
+            layoutParams.height = (imageHeight * value).toInt()
+            binding.cvBabyPhoto.layoutParams = layoutParams
+        }
+        scaleDownAnim.duration = 500 // 애니메이션 지속 시간 설정 (1000ms = 1초)
+
+
+        viewLifecycleOwner.repeatOnStarted {
+            viewModel.isPhotoExpended.collect {
+                getImgSize()
+                if (it) {
+                    scaleUpAnim.start()
+                    binding.cbAlbumLike.visibility = View.VISIBLE
+                } else {
+                    scaleDownAnim.start()
+                    binding.cbAlbumLike.visibility = View.GONE
+                }
+            }
+        }
+    }
+
     private fun setCloseBtn() {
         binding.btnDialogClose.setOnClickListener {
             dismiss()
         }
+        binding.tvAlbumDate.setOnClickListener {
+            viewModel.setExpended()
+        }
     }
 
-    private fun setBinding(){
+    private fun setBinding() {
         binding.lifecycleOwner = this.viewLifecycleOwner
         binding.viewModel = viewModel
     }

--- a/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.animation.doOnEnd
+import androidx.core.animation.doOnStart
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -103,7 +105,9 @@ class AlbumDetailDialog : DialogFragment() {
             binding.cvBabyPhoto.layoutParams = layoutParams
         }
         scaleUpAnim.duration = 500 // 애니메이션 지속 시간 설정 (1000ms = 1초)
-
+        scaleUpAnim.doOnEnd {
+            binding.cbAlbumLike.visibility = View.VISIBLE
+        }
         val scaleDownAnim = ValueAnimator.ofFloat(1f, 0.25f)
         scaleDownAnim.addUpdateListener { animation ->
             val layoutParams = binding.cvBabyPhoto.layoutParams
@@ -113,17 +117,17 @@ class AlbumDetailDialog : DialogFragment() {
             binding.cvBabyPhoto.layoutParams = layoutParams
         }
         scaleDownAnim.duration = 500 // 애니메이션 지속 시간 설정 (1000ms = 1초)
-
+        scaleDownAnim.doOnStart {
+            binding.cbAlbumLike.visibility = View.GONE
+        }
 
         viewLifecycleOwner.repeatOnStarted {
             viewModel.isPhotoExpended.collect {
                 if (it != null) {
                     if (it) {
                         scaleUpAnim.start()
-                        binding.cbAlbumLike.visibility = View.VISIBLE
                     } else {
                         scaleDownAnim.start()
-                        binding.cbAlbumLike.visibility = View.GONE
                     }
                 }
             }

--- a/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/AlbumDetailDialog.kt
@@ -9,6 +9,8 @@ import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import kids.baba.mobile.R
 import kids.baba.mobile.databinding.DialogFragmentAlbumDetailBinding
+import kids.baba.mobile.presentation.adapter.AlbumDetailCommentAdapter
+import kids.baba.mobile.presentation.extension.repeatOnStarted
 import kids.baba.mobile.presentation.viewmodel.AlbumDetailViewModel
 
 @AndroidEntryPoint
@@ -19,6 +21,8 @@ class AlbumDetailDialog : DialogFragment() {
         get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
 
     private val viewModel : AlbumDetailViewModel by viewModels()
+
+    private lateinit var commentAdapter: AlbumDetailCommentAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +43,19 @@ class AlbumDetailDialog : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         setBinding()
         setCloseBtn()
+        setCommentRecyclerView()
+    }
+
+    private fun setCommentRecyclerView() {
+        commentAdapter = AlbumDetailCommentAdapter()
+        binding.rvAlbumComment.adapter = commentAdapter
+
+        viewLifecycleOwner.repeatOnStarted {
+            viewModel.albumDetail.collect{
+                commentAdapter.submitList(it?.comments)
+            }
+        }
+
     }
 
     private fun setCloseBtn() {

--- a/app/src/main/java/kids/baba/mobile/presentation/view/IntroActivity.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/IntroActivity.kt
@@ -1,14 +1,15 @@
 package kids.baba.mobile.presentation.view
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kids.baba.mobile.R
+import kids.baba.mobile.databinding.ActivityIntroBinding
 import kids.baba.mobile.presentation.event.IntroEvent
 import kids.baba.mobile.presentation.extension.repeatOnStarted
 import kids.baba.mobile.presentation.view.signup.CreateProfileFragmentDirections
@@ -17,15 +18,16 @@ import kids.baba.mobile.presentation.viewmodel.IntroViewModel
 @AndroidEntryPoint
 class IntroActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityIntroBinding
     private val viewModel: IntroViewModel by viewModels()
 
     private lateinit var navController: NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_intro)
+        binding = ActivityIntroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setNavController()
         collectEvent()
     }
@@ -39,7 +41,6 @@ class IntroActivity : AppCompatActivity() {
     private fun collectEvent() {
         repeatOnStarted {
             viewModel.eventFlow.collect { event ->
-                Log.d("eventFlow",event.toString())
                 when (event) {
                     is IntroEvent.MoveToMain -> {
                         MainActivity.startActivity(this)
@@ -52,12 +53,14 @@ class IntroActivity : AppCompatActivity() {
                     }
                     is IntroEvent.MoveToCreateUserProfile -> {
                         val action = TermsAgreeFragmentDirections.actionTermsAgreeFragmentToCreateProfileFragment(event.signToken)
-                        Log.d("tertmsToCreate", event.signToken)
                         navController.navigate(action)
                     }
                     is IntroEvent.MoveToInputBabiesInfo -> {
                         val action = CreateProfileFragmentDirections.actionCreateProfileFragmentToInputBabiesInfoFragment(event.userProfile, event.signToken)
                         navController.navigate(action)
+                    }
+                    is IntroEvent.IntroError -> {
+                        Snackbar.make(binding.root, R.string.baba_intro_error,Snackbar.LENGTH_SHORT).show()
                     }
                     else -> Unit
                 }

--- a/app/src/main/java/kids/baba/mobile/presentation/view/IntroActivity.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/IntroActivity.kt
@@ -60,7 +60,7 @@ class IntroActivity : AppCompatActivity() {
                         navController.navigate(action)
                     }
                     is IntroEvent.IntroError -> {
-                        Snackbar.make(binding.root, R.string.baba_intro_error,Snackbar.LENGTH_SHORT).show()
+                        Snackbar.make(binding.root, R.string.baba_unknown_error,Snackbar.LENGTH_SHORT).show()
                     }
                     else -> Unit
                 }

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
@@ -14,18 +14,18 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AlbumDetailViewModel @Inject constructor(
-)  : ViewModel(){
+) : ViewModel() {
 
     val albumDetail = MutableStateFlow<AlbumDetailUiModel?>(null)
     val album = MutableStateFlow<AlbumUiModel?>(null)
 
-    private val _isPhotoExpended = MutableStateFlow(true)
+    private val _isPhotoExpended: MutableStateFlow<Boolean?> = MutableStateFlow(null)
     val isPhotoExpended = _isPhotoExpended.asStateFlow()
     init {
         getAlbumDetail()
     }
 
-    private fun getAlbumDetail(){
+    private fun getAlbumDetail() {
         val tempAlbum = AlbumUiModel(
             contentId = 111,
             name = "박재희",
@@ -66,14 +66,105 @@ class AlbumDetailViewModel @Inject constructor(
                     tag = "이호성",
                     comment = "댓글 테스트2",
                     createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 3,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 4,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 6,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 7,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 8,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 9,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 10,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
+                ),
+                CommentUiModel(
+                    commentId = 11,
+                    memberId = "222",
+                    name = "박재희",
+                    relation = "엄마",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
+                    iconColor = "#FFA500",
+                    tag = "이호성",
+                    comment = "댓글 테스트2",
+                    createdAt = LocalDateTime.now()
                 )
+
             )
         )
         albumDetail.value = tempAlbumDetail
         album.value = tempAlbum
     }
 
-    fun setExpended(){
-        _isPhotoExpended.value = _isPhotoExpended.value.not()
+    fun setExpended(expended: Boolean) {
+        if (expended != _isPhotoExpended.value) {
+            _isPhotoExpended.value = expended
+        }
     }
 }

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
@@ -2,7 +2,6 @@ package kids.baba.mobile.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kids.baba.mobile.R
 import kids.baba.mobile.presentation.model.AlbumDetailUiModel
 import kids.baba.mobile.presentation.model.AlbumUiModel
 import kids.baba.mobile.presentation.model.CommentUiModel
@@ -36,9 +35,9 @@ class AlbumDetailViewModel @Inject constructor(
         val tempAlbumDetail = AlbumDetailUiModel(
             likeCount = 3,
             likeUsers = listOf(
-                UserIconUiModel(R.drawable.profile_g_1, "#FFA500"),
-                UserIconUiModel(R.drawable.profile_g_2, "#BACEE0"),
-                UserIconUiModel(R.drawable.profile_g_3, "#629755")
+                UserIconUiModel(UserProfileIconUiModel.PROFILE_G_1, "#FFA500"),
+                UserIconUiModel(UserProfileIconUiModel.PROFILE_G_2, "#BACEE0"),
+                UserIconUiModel(UserProfileIconUiModel.PROFILE_G_3, "#629755")
             ),
             commentCount = 2,
             comments = listOf(

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
@@ -7,6 +7,7 @@ import kids.baba.mobile.presentation.model.AlbumDetailUiModel
 import kids.baba.mobile.presentation.model.AlbumUiModel
 import kids.baba.mobile.presentation.model.CommentUiModel
 import kids.baba.mobile.presentation.model.UserIconUiModel
+import kids.baba.mobile.presentation.model.UserProfileIconUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.LocalDateTime
 import javax.inject.Inject
@@ -46,8 +47,8 @@ class AlbumDetailViewModel @Inject constructor(
                     memberId = "111",
                     name = "이호성",
                     relation = "친구",
-                    iconName = R.drawable.profile_m_5,
-                    iconColor = "FFA500",
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_1,
+                    iconColor = "#629755",
                     tag = "",
                     comment = "댓글 테스트",
                     createdAt = LocalDateTime.now()
@@ -57,7 +58,7 @@ class AlbumDetailViewModel @Inject constructor(
                     memberId = "222",
                     name = "박재희",
                     relation = "엄마",
-                    iconName = R.drawable.profile_w_1,
+                    profileIcon = UserProfileIconUiModel.PROFILE_G_3,
                     iconColor = "FFA500",
                     tag = "",
                     comment = "댓글 테스트2",

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
@@ -8,6 +8,7 @@ import kids.baba.mobile.presentation.model.CommentUiModel
 import kids.baba.mobile.presentation.model.UserIconUiModel
 import kids.baba.mobile.presentation.model.UserProfileIconUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -17,6 +18,9 @@ class AlbumDetailViewModel @Inject constructor(
 
     val albumDetail = MutableStateFlow<AlbumDetailUiModel?>(null)
     val album = MutableStateFlow<AlbumUiModel?>(null)
+
+    private val _isPhotoExpended = MutableStateFlow(true)
+    val isPhotoExpended = _isPhotoExpended.asStateFlow()
     init {
         getAlbumDetail()
     }
@@ -67,5 +71,9 @@ class AlbumDetailViewModel @Inject constructor(
         )
         albumDetail.value = tempAlbumDetail
         album.value = tempAlbum
+    }
+
+    fun setExpended(){
+        _isPhotoExpended.value = _isPhotoExpended.value.not()
     }
 }

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/AlbumDetailViewModel.kt
@@ -59,8 +59,8 @@ class AlbumDetailViewModel @Inject constructor(
                     name = "박재희",
                     relation = "엄마",
                     profileIcon = UserProfileIconUiModel.PROFILE_G_3,
-                    iconColor = "FFA500",
-                    tag = "",
+                    iconColor = "#FFA500",
+                    tag = "이호성",
                     comment = "댓글 테스트2",
                     createdAt = LocalDateTime.now()
                 )

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
@@ -3,12 +3,14 @@ package kids.baba.mobile.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kids.baba.mobile.core.error.TokenEmptyException
 import kids.baba.mobile.domain.model.MemberModel
 import kids.baba.mobile.domain.usecase.GetMemberUseCase
 import kids.baba.mobile.presentation.event.IntroEvent
 import kids.baba.mobile.presentation.model.UserProfile
 import kids.baba.mobile.presentation.util.flow.MutableEventFlow
 import kids.baba.mobile.presentation.util.flow.asEventFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,9 +30,14 @@ class IntroViewModel @Inject constructor(
     private fun checkLogin() {
         viewModelScope.launch {
             getMemberUseCase.getMe()
-                .onFailure {
-                    _eventFlow.emit(IntroEvent.StartOnBoarding)
-                }.onSuccess {
+                .catch {
+                    if(it is TokenEmptyException){
+                        _eventFlow.emit(IntroEvent.StartOnBoarding)
+                    } else {
+                        _eventFlow.emit(IntroEvent.IntroError)
+                    }
+                }
+                .collect {
                     _eventFlow.emit(IntroEvent.MoveToMain(it))
                 }
         }

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
@@ -38,7 +38,7 @@ class IntroViewModel @Inject constructor(
                     }
                 }
                 .collect {
-                    _eventFlow.emit(IntroEvent.MoveToMain(it))
+                    _eventFlow.emit(IntroEvent.MoveToMain)
                 }
         }
     }
@@ -49,9 +49,9 @@ class IntroViewModel @Inject constructor(
         }
     }
 
-    fun isLoginSuccess(member: MemberModel) {
+    fun isLoginSuccess() {
         viewModelScope.launch {
-            _eventFlow.emit(IntroEvent.MoveToMain(member))
+            _eventFlow.emit(IntroEvent.MoveToMain)
         }
     }
 

--- a/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/viewmodel/IntroViewModel.kt
@@ -9,7 +9,6 @@ import kids.baba.mobile.presentation.event.IntroEvent
 import kids.baba.mobile.presentation.model.UserProfile
 import kids.baba.mobile.presentation.util.flow.MutableEventFlow
 import kids.baba.mobile.presentation.util.flow.asEventFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,11 +27,12 @@ class IntroViewModel @Inject constructor(
 
     private fun checkLogin() {
         viewModelScope.launch {
-            getMemberUseCase.getMe().catch {
-                _eventFlow.emit(IntroEvent.StartOnBoarding)
-            }.collect {
-                _eventFlow.emit(IntroEvent.MoveToMain(it))
-            }
+            getMemberUseCase.getMe()
+                .onFailure {
+                    _eventFlow.emit(IntroEvent.StartOnBoarding)
+                }.onSuccess {
+                    _eventFlow.emit(IntroEvent.MoveToMain(it))
+                }
         }
     }
 
@@ -66,7 +66,7 @@ class IntroViewModel @Inject constructor(
         }
     }
 
-    fun isSignUpSuccess(member: MemberModel){
+    fun isSignUpSuccess(member: MemberModel) {
 
     }
 }

--- a/app/src/main/res/layout/dialog_fragment_album_detail.xml
+++ b/app/src/main/res/layout/dialog_fragment_album_detail.xml
@@ -248,6 +248,8 @@
                     android:layout_width="30dp"
                     android:layout_height="30dp"
                     android:layout_marginBottom="20dp"
+                    app:backGroundColor="@{viewModel.member.userIconUiModel.iconColor}"
+                    app:iconRes="@{viewModel.member.userIconUiModel.userProfileIconUiModel.iconRes}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="@id/tv_album_date"
                     tools:civ_circle_background_color="@color/baba_main"

--- a/app/src/main/res/layout/dialog_fragment_album_detail.xml
+++ b/app/src/main/res/layout/dialog_fragment_album_detail.xml
@@ -131,6 +131,7 @@
                 </androidx.cardview.widget.CardView>
 
                 <CheckBox
+                    android:id="@+id/cb_album_like"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="18dp"

--- a/app/src/main/res/layout/dialog_fragment_album_detail.xml
+++ b/app/src/main/res/layout/dialog_fragment_album_detail.xml
@@ -227,7 +227,6 @@
                     android:id="@+id/rv_album_comment"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintBottom_toTopOf="@id/dv_comment_end"
                     app:layout_constraintEnd_toEndOf="@id/btn_album_config"
                     app:layout_constraintStart_toStartOf="@id/cl_like_users"

--- a/app/src/main/res/layout/dialog_fragment_album_detail.xml
+++ b/app/src/main/res/layout/dialog_fragment_album_detail.xml
@@ -9,6 +9,7 @@
             name="viewModel"
             type="kids.baba.mobile.presentation.viewmodel.AlbumDetailViewModel" />
 
+        <import type="java.util.List" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -121,10 +122,10 @@
                     app:layout_constraintTop_toBottomOf="@+id/tv_album_title">
 
                     <ImageView
-                        app:imageFromUrl="@{viewModel.album.photo}"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:scaleType="fitXY"
+                        app:imageFromUrl="@{viewModel.album.photo}"
                         tools:src="@mipmap/ic_launcher" />
 
                 </androidx.cardview.widget.CardView>
@@ -155,8 +156,10 @@
                         android:layout_width="22dp"
                         android:layout_height="22dp"
                         android:layout_marginStart="36dp"
+                        app:backGroundColor="@{viewModel.albumDetail.likeUsers.get(2).iconColor}"
                         app:civ_border_color="@color/white"
                         app:civ_border_width="2dp"
+                        app:iconRes="@{viewModel.albumDetail.likeUsers.get(2).userProfileIconUiModel.iconRes}"
                         app:layout_constraintBottom_toBottomOf="@id/civ_like_user_1"
                         app:layout_constraintStart_toStartOf="@id/civ_like_user_1"
                         app:layout_constraintTop_toTopOf="@+id/civ_like_user_1"
@@ -168,8 +171,10 @@
                         android:layout_width="22dp"
                         android:layout_height="22dp"
                         android:layout_marginStart="18dp"
+                        app:backGroundColor="@{viewModel.albumDetail.likeUsers.get(1).iconColor}"
                         app:civ_border_color="@color/white"
                         app:civ_border_width="2dp"
+                        app:iconRes="@{viewModel.albumDetail.likeUsers.get(1).userProfileIconUiModel.iconRes}"
                         app:layout_constraintBottom_toBottomOf="@id/civ_like_user_1"
                         app:layout_constraintStart_toStartOf="@id/civ_like_user_1"
                         app:layout_constraintTop_toTopOf="@+id/civ_like_user_1"
@@ -180,8 +185,10 @@
                         android:id="@+id/civ_like_user_1"
                         android:layout_width="22dp"
                         android:layout_height="22dp"
+                        app:backGroundColor="@{viewModel.albumDetail.likeUsers.get(0).iconColor}"
                         app:civ_border_color="@color/white"
                         app:civ_border_width="2dp"
+                        app:iconRes="@{viewModel.albumDetail.likeUsers.get(0).userProfileIconUiModel.iconRes}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/item_album_comment.xml
+++ b/app/src/main/res/layout/item_album_comment.xml
@@ -1,73 +1,104 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginVertical="10dp">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/civ_user_icon"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/tv_comment_name"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0"
-        tools:civ_circle_background_color="@color/baba_main"
-        tools:src="@drawable/profile_w_5" />
+    <data>
 
-    <TextView
-        android:id="@+id/tv_comment_name"
-        android:layout_width="wrap_content"
+        <variable
+            name="comment"
+            type="kids.baba.mobile.presentation.model.CommentUiModel" />
+
+        <import type="android.view.View"/>
+        <import type="String"/>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:includeFontPadding="false"
-        android:textAppearance="@style/BABA.TextStyle"
-        app:layout_constraintBottom_toBottomOf="@id/civ_user_icon"
-        app:layout_constraintEnd_toStartOf="@id/tv_comment_relation"
-        app:layout_constraintStart_toEndOf="@id/civ_user_icon"
-        app:layout_constraintTop_toTopOf="@id/civ_user_icon"
-        tools:text="박재희" />
+        android:layout_marginVertical="10dp">
 
-    <TextView
-        android:id="@+id/tv_comment_relation"
-        style="@style/BABA.TextStyle.Relation"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
-        android:background="@drawable/bg_album_relation"
-        android:textAppearance="@style/BABA.TextStyle"
-        app:layout_constraintBottom_toBottomOf="@id/civ_user_icon"
-        app:layout_constraintStart_toEndOf="@id/tv_comment_name"
-        app:layout_constraintTop_toTopOf="@id/civ_user_icon"
-        tools:text="친구" />
+        <de.hdodenhof.circleimageview.CircleImageView
+            android:id="@+id/civ_user_icon"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_comment_name"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0"
+            tools:civ_circle_background_color="@color/baba_main"
+            tools:src="@drawable/profile_w_5" />
 
-    <TextView
-        android:id="@+id/tv_comment_date"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:includeFontPadding="false"
-        android:textAppearance="@style/BABA.TextStyle"
-        android:textColor="@color/text_3"
-        android:textSize="11sp"
-        app:layout_constraintBottom_toBottomOf="@+id/civ_user_icon"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1"
-        app:layout_constraintStart_toEndOf="@+id/tv_comment_relation"
-        app:layout_constraintTop_toTopOf="@+id/civ_user_icon"
-        tools:text="09-28 15:37" />
+        <TextView
+            android:id="@+id/tv_comment_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:includeFontPadding="false"
+            android:text="@{comment.name}"
+            android:textAppearance="@style/BABA.TextStyle"
+            app:layout_constraintBottom_toBottomOf="@id/civ_user_icon"
+            app:layout_constraintEnd_toStartOf="@id/tv_comment_relation"
+            app:layout_constraintStart_toEndOf="@id/civ_user_icon"
+            app:layout_constraintTop_toTopOf="@id/civ_user_icon"
+            tools:text="박재희" />
 
-    <TextView
-        android:id="@+id/tv_comment_content"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:includeFontPadding="false"
-        android:textAppearance="@style/BABA.TextStyle"
-        app:layout_constraintStart_toStartOf="@id/tv_comment_name"
-        app:layout_constraintTop_toBottomOf="@id/tv_comment_name"
-        tools:text="제인아, 앙쥬 너무 귀엽다 ㅋㅋ" />
+        <TextView
+            android:id="@+id/tv_comment_relation"
+            style="@style/BABA.TextStyle.Relation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/bg_album_relation"
+            android:text="@{comment.relation"
+            android:textAppearance="@style/BABA.TextStyle"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_comment_name"
+            app:layout_constraintStart_toEndOf="@id/tv_comment_name"
+            app:layout_constraintTop_toTopOf="@+id/tv_comment_name"
+            tools:text="친구" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/tv_comment_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:includeFontPadding="false"
+            android:textAppearance="@style/BABA.TextStyle"
+            android:textColor="@color/text_3"
+            android:textSize="11sp"
+            app:layout_constraintBottom_toBottomOf="@+id/civ_user_icon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toEndOf="@+id/tv_comment_relation"
+            app:layout_constraintTop_toTopOf="@+id/civ_user_icon"
+            tools:text="09-28 15:37" />
+
+        <TextView
+            android:id="@+id/tv_comment_tag"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:includeFontPadding="false"
+            android:visibility="@{comment.tag.empty ? View.VISIBLE : View.GONE}"
+            android:text="@{@string/album_comment_tag(comment.tag)}"
+            android:textAppearance="@style/BABA.TextStyle"
+            android:textColor="@color/baba_main"
+            app:layout_constraintEnd_toStartOf="@id/tv_comment_content"
+            app:layout_constraintStart_toStartOf="@id/tv_comment_name"
+            app:layout_constraintTop_toBottomOf="@id/tv_comment_name"
+            tools:text="\@박재희" />
+
+        <TextView
+            android:id="@+id/tv_comment_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:includeFontPadding="false"
+            android:textAppearance="@style/BABA.TextStyle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_comment_tag"
+            app:layout_constraintTop_toBottomOf="@id/tv_comment_name"
+            tools:text="제인아, 앙쥬 너무 귀엽다 ㅋㅋ" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_album_comment.xml
+++ b/app/src/main/res/layout/item_album_comment.xml
@@ -10,7 +10,6 @@
             type="kids.baba.mobile.presentation.model.CommentUiModel" />
 
         <import type="android.view.View"/>
-        <import type="String"/>
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -19,6 +18,8 @@
         android:layout_marginVertical="10dp">
 
         <de.hdodenhof.circleimageview.CircleImageView
+            app:iconRes="@{comment.profileIcon.iconRes}"
+            app:backGroundColor="@{comment.iconColor}"
             android:id="@+id/civ_user_icon"
             android:layout_width="30dp"
             android:layout_height="30dp"
@@ -51,7 +52,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:background="@drawable/bg_album_relation"
-            android:text="@{comment.relation"
+            android:text="@{comment.relation}"
             android:textAppearance="@style/BABA.TextStyle"
             app:layout_constraintBottom_toBottomOf="@+id/tv_comment_name"
             app:layout_constraintStart_toEndOf="@id/tv_comment_name"
@@ -80,7 +81,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="4dp"
             android:includeFontPadding="false"
-            android:visibility="@{comment.tag.empty ? View.VISIBLE : View.GONE}"
+            android:visibility="@{comment.tag.empty ? View.GONE : View.VISIBLE}"
             android:text="@{@string/album_comment_tag(comment.tag)}"
             android:textAppearance="@style/BABA.TextStyle"
             android:textColor="@color/baba_main"
@@ -96,6 +97,7 @@
             android:includeFontPadding="false"
             android:textAppearance="@style/BABA.TextStyle"
             app:layout_constraintEnd_toEndOf="parent"
+            android:text="@{comment.comment}"
             app:layout_constraintStart_toEndOf="@id/tv_comment_tag"
             app:layout_constraintTop_toBottomOf="@id/tv_comment_name"
             tools:text="제인아, 앙쥬 너무 귀엽다 ㅋㅋ" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="on_boarding_title3">속닥속닥, 우리끼리</string>
     <string name="on_boarding_body3">같은 그룹인 경우에만 댓글이 보여요!\n편하게 대화를 나누어요 :)</string>
     <string name="baba_start">시작하기</string>
-    <string name="baba_intro_error">정보 확인에 문제가 발생했습니다.</string>
     <string name="baba_login_title">바바에서\n추억을 기록해요</string>
     <string name="baba_login_body">아이와 함께 성장을 기록해요</string>
     <string name="baba_terms_description">로그인 시 바바 개인정보처리방침,\n이용약관에 동의합니다.</string>
@@ -48,6 +47,8 @@
     <string name="answer_no">아니</string>
     <string name="need_to_baby_info">추억을 기록하기 전 아이의 정보가 필요해요!</string>
     <string name="what_is_the_name_of_baby">기록할 아이의 이름이 무엇인가요?</string>
+    <string name="baba_unknown_error">동작에 문제가 발생했습니다.</string>
+    <string name="baba_token_empty_error">토큰 확인에 문제가 발생했습니다.</string>
 
     <string name="monday"> 월</string>
     <string name="tuesday"> 화</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="input_end_babies_info">좋아요!\n아래 버튼을 눌러 시작해봐요!</string>
     <string name="add_comment">[아이이름]에게 댓글달기</string>
     <string name="album_like_count">좋아요 %d개</string>
+    <string name="album_comment_tag">%@%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,5 +67,5 @@
     <string name="input_end_babies_info">좋아요!\n아래 버튼을 눌러 시작해봐요!</string>
     <string name="add_comment">[아이이름]에게 댓글달기</string>
     <string name="album_like_count">좋아요 %d개</string>
-    <string name="album_comment_tag">%@%s</string>
+    <string name="album_comment_tag">\@%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="on_boarding_title3">속닥속닥, 우리끼리</string>
     <string name="on_boarding_body3">같은 그룹인 경우에만 댓글이 보여요!\n편하게 대화를 나누어요 :)</string>
     <string name="baba_start">시작하기</string>
+    <string name="baba_intro_error">정보 확인에 문제가 발생했습니다.</string>
     <string name="baba_login_title">바바에서\n추억을 기록해요</string>
     <string name="baba_login_body">아이와 함께 성장을 기록해요</string>
     <string name="baba_terms_description">로그인 시 바바 개인정보처리방침,\n이용약관에 동의합니다.</string>


### PR DESCRIPTION
### 추가구현 필요
- 앨범 자세히보기 api
- 댓글 작성 기능 + api
- 댓글 삭제 기능 + api
- 좋아요 api
- 앨범 우 상단 더보기 (이 기능은 메인화면의 앨범과 같은 기능이라 한번에 구현하는 것이 좋을것 같습니다.)

sharedPrefsFile로 현재 사용자의 정보를 저장하도록 해뒀습니다. 필요에 따라 꺼내 쓰면 될것 같습니다.

https://user-images.githubusercontent.com/54586491/227940554-c5d33248-2b5c-449e-8cda-8ee084bfab59.mp4

