### PR TITLE
바텀시트로 인해 가려지던 스낵바의 위치 조절

### DIFF
--- a/app/src/main/java/kids/baba/mobile/presentation/view/bottomsheet/BabyListBottomSheet.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/bottomsheet/BabyListBottomSheet.kt
@@ -78,7 +78,6 @@ class BabyListBottomSheet(
     }
 
     private fun showSnackBar(@StringRes message: Int) {
-        //TODO 바텀시트에 가려져 스낵바가 보이지 않음
         Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
             .apply {
                 anchorView = binding.root

--- a/app/src/main/java/kids/baba/mobile/presentation/view/bottomsheet/BabyListBottomSheet.kt
+++ b/app/src/main/java/kids/baba/mobile/presentation/view/bottomsheet/BabyListBottomSheet.kt
@@ -79,7 +79,10 @@ class BabyListBottomSheet(
 
     private fun showSnackBar(@StringRes message: Int) {
         //TODO 바텀시트에 가려져 스낵바가 보이지 않음
-        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
+            .apply {
+                anchorView = binding.root
+            }.show()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
바텀시트는 항상 최상단에 위치하여 스낵바의 위치를 덮어서 화면에 보이지 않는 문제가 있었는 데 스낵바의 속성값 변경을 통해 anchorView로 선언한 뷰의 상단에 스낵바가 위치하도록 구현할 수 있었습니다. 우선 제가 구현한 내용 중 이 부분만 수정되었는데 혹시 다른 부분도 같은 수정이 필요한 부분이 있을까요?
![image](https://github.com/BA-BA-Project/BaBa.Application/assets/54586491/8b1fad3f-0470-4602-b3e2-9731e9190483)
